### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -1,5 +1,5 @@
 kafka_pool: nav-dev
 dokdistfordeling:
   url: "https://dokdistfordeling-q1.dev-fss-pub.nais.io/rest/v1/distribuerjournalpost"
-  apiScope: "api://dev-fss.teamdokumenthandtering.saf-q1/.default"
+  apiScope: "api://dev-fss.teamdokumenthandtering.dokdistfordeling-q1/.default"
   host: "dokdistfordeling-q1.dev-fss-pub.nais.io"

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -1,5 +1,5 @@
 kafka_pool: nav-prod
 dokdistfordeling:
   url: "https://dokdistfordeling.prod-fss-pub.nais.io/rest/v1/distribuerjournalpost"
-  apiScope: "api://prod-fss.teamdokumenthandtering.saf/.default"
+  apiScope: "api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default"
   host: "dokdistfordeling.prod-fss-pub.nais.io"


### PR DESCRIPTION
* Endret fra saf-scope til dokdistfordeling-scope

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-gcp:teamdagpenger:dp-behov-distribuering` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇